### PR TITLE
docs: mention new options in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,16 @@ Usage: staledeps <path(s)> [options]
 Options:
       --version    Show version number                                 [boolean]
   -h, --help       Show help                                           [boolean]
+  -d, --sort-dir   Direction to sort data
+                                       [choices: "asc", "desc"] [default: "asc"]
   -f, --full       Show full report (including non-stale dependencies)
                                                       [boolean] [default: false]
+  -o, --output     Format to output data
+                                   [choices: "json", "table"] [default: "table"]
   -r, --registry   URL of registry to check against
                                          [default: "https://registry.npmjs.org"]
+  -s, --sort       Field to sort data
+                              [choices: "name", "lastPublish"] [default: "name"]
   -t, --threshold  Threshold to be determined as stale (see vercel/ms)
                                                                  [default: "2y"]
 


### PR DESCRIPTION
This builds on top of https://github.com/pmmmwh/staledeps/pull/308 which ensures the output includes the list of choices for each option.

Follow-up to:
* https://github.com/pmmmwh/staledeps/pull/306
* https://github.com/pmmmwh/staledeps/pull/307
